### PR TITLE
Use scheme-aware colors on home page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -9,10 +9,10 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="min-h-screen bg-black text-white px-6 py-10 sm:px-8 md:px-10">
+      <main className="min-h-screen bg-background text-foreground px-6 py-10 sm:px-8 md:px-10">
         <div className="max-w-3xl mx-auto space-y-8 leading-relaxed text-base">
 
-          <h1 className="text-3xl font-bold text-white">MaxedOut Flux Installer Guide 🚀</h1>
+          <h1 className="text-3xl font-bold text-foreground">MaxedOut Flux Installer Guide 🚀</h1>
           <p>
             This guide walks you through the manual setup for the Flux Kontext workflow.
             For the best experience, right-click any file link and choose <strong>“Save Link As…”</strong> into the specified folder.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,12 @@
 module.exports = {
   content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add `background` and `foreground` colors in Tailwind config
- use the new color classes on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad5a914a083319a2d7ceb0a9fef33