### PR TITLE
Add Geist Sans font globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "15.4.4",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "@next/font": "latest"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,12 @@
 import "@/styles/globals.css";
+import { GeistSans } from "next/font/google";
+
+const geist = GeistSans({ subsets: ["latin"] });
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <main className={geist.className}>
+      <Component {...pageProps} />
+    </main>
+  );
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,10 +1,13 @@
 import { Html, Head, Main, NextScript } from "next/document";
+import { GeistSans } from "next/font/google";
+
+const geist = GeistSans({ subsets: ["latin"] });
 
 export default function Document() {
   return (
     <Html lang="en">
       <Head />
-      <body>
+      <body className={geist.className}>
         <Main />
         <NextScript />
       </body>


### PR DESCRIPTION
## Summary
- install `@next/font` dependency
- add GeistSans font import in `_app.js`
- apply GeistSans to `<body>` via custom Document

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad5ab5a288331b8314875184ed87e